### PR TITLE
Modernize and align with my usual settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @jenkinsci/disable-job-button-plugin-developers
+# Limit automatic code review requests to production code changes
+/src/main/ @jenkinsci/disable-job-button-plugin-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,18 @@
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
-
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: /
-  schedule:
-    interval: monthly
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    ignore:
+      # BOM and build dependencies are excluded, they are released far too often and matter too little
+      - dependency-name: "io.jenkins.tools.bom:bom-2.*.x"
+      - dependency-name: "io.jenkins.tools.incrementals:git-changelist-maven-extension"
+      - dependency-name: "org.jenkins-ci.plugins:plugin"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,4 @@
-name: Continuous Delivery
+name: JEP-229 CD
 on:
   workflow_dispatch:
 

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,10 +1,7 @@
-# More information about the Jenkins security scan can be found at the developer docs: https://www.jenkins.io/redirect/jenkins-security-scan/
-
 name: Jenkins Security Scan
 on:
   push:
     branches:
-      - "master"
       - "main"
   pull_request:
     types: [ opened, synchronize, reopened ]
@@ -19,5 +16,4 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      java-version: 11 # What version of Java to set up for the build.
+      java-cache: 'maven'

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,26 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.85</version>
+    <version>5.22</version>
     <relativePath />
   </parent>
 
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>disable-job-button</artifactId>
-  <version>${changelist}</version>
+  <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Disable Job Button Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+
   <licenses>
     <license>
       <name>MIT License</name>
       <url>https://opensource.org/license/mit/</url>
     </license>
   </licenses>
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+
+  <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
@@ -30,24 +32,13 @@
   </scm>
 
   <properties>
+    <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <!-- first jenkins.version without built-in Disable button -->
-    <jenkins.version>2.460</jenkins.version>
+    <jenkins.version>2.479.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.452.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <repositories>
     <repository>


### PR DESCRIPTION
- Update to 2.479.3
- Remove unused reference to BOM
- Update parent POM and incrementals extension
- Add prefix for CD versioning to prevent excessive version growth
- Limit CODEOWNERS to /src/main/
- Let JSS action choose Java version
- Exclude parent POM etc. from Dependabot
- Rename CD action
