### PR TITLE
Add support for disabling certain folders, like Multibranch Pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,31 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.479.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>

--- a/src/main/java/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction.java
+++ b/src/main/java/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.disable_job_button;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import java.util.List;
+import jenkins.model.TransientActionFactory;
+
+public class DisableFolderButtonAction extends InvisibleAction {
+    private final transient AbstractFolder folder;
+
+    public DisableFolderButtonAction(AbstractFolder folder) {
+        this.folder = folder;
+    }
+
+    // Jelly
+    public AbstractFolder getFolder() {
+        return folder;
+    }
+
+    @Extension
+    public static class DisableFolderButtonActionFactory extends TransientActionFactory<AbstractFolder> {
+
+        @Override
+        public Class<AbstractFolder> type() {
+            return AbstractFolder.class;
+        }
+
+        @Override
+        public java.util.Collection<? extends Action> createFor(AbstractFolder target) {
+            if (!target.supportsMakeDisabled()) {
+                return List.of();
+            }
+            return List.of(new DisableFolderButtonAction(target));
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction/summary.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <j:if test="${it.folder.supportsMakeDisabled() and !it.folder.disabled}">
+        <l:hasPermission permission="${it.folder.CONFIGURE}">
+            <div align="right">
+                <form method="post" id="disable-project" action="${rootURL}/${it.folder.url}disable">
+                    <f:submit value="${%disable(it.folder.pronoun)}"/>
+                </form>
+            </div>
+        </l:hasPermission>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction/summary.properties
+++ b/src/main/resources/io/jenkins/plugins/disable_job_button/DisableFolderButtonAction/summary.properties
@@ -1,0 +1,1 @@
+disable=Disable {0}


### PR DESCRIPTION
Resolves https://github.com/jenkinsci/disable-job-button-plugin/issues/3.

### Testing done

Disabled MBPL:
<img width="1111" height="384" alt="Screenshot 2025-08-16 at 12 43 23" src="https://github.com/user-attachments/assets/1cd95616-12aa-44a0-8e90-11f0f117beb0" />

After button click:
<img width="1110" height="368" alt="Screenshot 2025-08-16 at 12 43 27" src="https://github.com/user-attachments/assets/be9e0381-2eef-4a85-b0f8-ef0b4a0286c2" />

https://github.com/jenkinsci/cloudbees-folder-plugin/pull/525 restores the corresponding "Enable" button.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
